### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,76 @@
+language: C
+env:
+  global:
+    - IDE_VERSION=1.8.13
+    - TEENSY_VERSION=153
+matrix:
+  include:
+    - name: "Arduino Uno"
+      env: BOARD=arduino:avr:uno PCINT=true
+    - name: "Arduino Leonardo"
+      env: BOARD=arduino:avr:leonardo PCINT=true
+    - name: "Arduino Mega"
+      env: BOARD=arduino:avr:mega:cpu=atmega2560 PCINT=true
+    - name: "Teensy LC"
+      env: BOARD=teensy:avr:teensyLC:usb=serial,speed=48,opt=osstd,keys=en-us PCINT=false
+
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
+  - sleep 3
+  - export DISPLAY=:1.0
+
+  # Install Arduino IDE
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - sudo mv arduino-$IDE_VERSION /usr/local/share/arduino
+  - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+
+  # Install Teensyduino
+  - if [[ $BOARD == *"teensy"* ]]; then
+      wget https://www.pjrc.com/teensy/td_$TEENSY_VERSION/TeensyduinoInstall.linux64;
+      chmod +x ./TeensyduinoInstall.linux64;
+      sudo ./TeensyduinoInstall.linux64 --dir=/usr/local/share/arduino;
+    fi
+
+  # Sketch Compiling Functions
+  - CYAN="\033[36m"; NOC="\033[0m";
+  - buildSketchPath() {
+      sktch=${1##*/examples/};
+      sktch=${sktch%/*.ino};
+      echo -e "\n${CYAN}Building sketch $sktch.ino${NOC}";
+      arduino --verify --board $BOARD "$1";
+    }
+  - buildExampleSketch() {
+      buildSketchPath "$PWD/examples/$1/$1.ino";
+    }
+  - buildExampleFolder() {
+      echo "Building example folder /$1/";
+      IFS=$'\n'; set -f;
+      for f in $(find $PWD/examples/"$1" -name '*.ino');
+      do
+        buildSketchPath $f;
+      done;
+      unset IFS; set +f;
+    }
+
+install:
+  - ln -s $PWD /usr/local/share/arduino/libraries/ServoInput
+  - arduino --install-library "PinChangeInterrupt"
+
+script:
+  - buildExampleSketch BasicAngle
+  - buildExampleSketch Calibration
+  - buildExampleSketch Loopback
+  - buildExampleSketch RC_Receiver
+  - buildExampleSketch Remapping
+  - if [ "$PCINT" = "true" ]; then
+      echo "Board supports pin change interrupts";
+      buildExampleFolder PinChangeInt;
+    else
+      echo "Board does not support PCINT, not building PinChangeInt examples";
+    fi
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ script:
   - buildExampleSketch RC_Receiver
   - buildExampleSketch Remapping
   - if [ "$PCINT" = "true" ]; then
-      echo "Board supports pin change interrupts";
+      echo -e "\n${CYAN}Board supports pin change interrupts! Building those examples now${NOC}\n";
       buildExampleFolder PinChangeInt;
     else
-      echo "Board does not support PCINT, not building PinChangeInt examples";
+      echo -e "\n${CYAN}Board does not support PCINT, not building PinChangeInt examples${NOC}\n";
     fi
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Servo Input Library
+[![Build Status](https://travis-ci.com/dmadison/ServoInput.svg?branch=master)](https://travis-ci.com/dmadison/ServoInput)
 
 This is an Arduino library that allows you to read the position of servo motors via their signal wire without delay. You can use this library to read RC receiver channels, find the motor positions of robotics, or debug other servo motor projects.
 


### PR DESCRIPTION
Adds Travis CI support, building for the following boards:

* Arduino Uno (328P)
* Arduino Leonardo (32U4)
* Arduino Mega (2560)
* Teensy LC