### PR TITLE
Arduino MKR Boards Support

### DIFF
--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -92,7 +92,7 @@ class ServoInputPin : public ServoInputSignal {
 public:
 	ServoInputPin() {
 		ServoInputPin<Pin>::PinMask = PIN_TO_BITMASK(Pin);
-		ServoInputPin<Pin>::Port = PIN_TO_BASEREG(Pin);
+		ServoInputPin<Pin>::PortRegister = PIN_TO_BASEREG(Pin);
 		pinMode(Pin, INPUT_PULLUP);
 
 		attachInterrupt();
@@ -168,7 +168,7 @@ public:
 	static void SERVOINPUT_ISR_FLAG isr() {
 		static unsigned long start = 0;
 
-		const boolean state = DIRECT_PIN_READ(Port, PinMask);
+		const boolean state = DIRECT_PIN_READ(PortRegister, PinMask);
 
 		if (state == HIGH) {  // rising edge
 			start = micros();
@@ -181,7 +181,7 @@ public:
 
 protected:
 	static IO_REG_TYPE PinMask;
-	static volatile IO_REG_TYPE* Port;
+	static volatile IO_REG_TYPE* PortRegister;
 
 	static volatile boolean changed;
 	static volatile unsigned long pulseDuration;
@@ -197,7 +197,7 @@ protected:
 };
 
 template<uint8_t Pin> IO_REG_TYPE ServoInputPin<Pin>::PinMask;
-template<uint8_t Pin> volatile IO_REG_TYPE* ServoInputPin<Pin>::Port;
+template<uint8_t Pin> volatile IO_REG_TYPE* ServoInputPin<Pin>::PortRegister;
 
 template<uint8_t Pin> volatile boolean ServoInputPin<Pin>::changed = false;
 template<uint8_t Pin> volatile unsigned long ServoInputPin<Pin>::pulseDuration = 0;

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -20,6 +20,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// This file borrows the formating and naming conventions from Paul Stoffregen's
+// Encoder library. Thanks Paul!
+// https://github.com/PaulStoffregen/Encoder/blob/master/utility/direct_pin_read.h
+
 #ifndef ServoInput_Platforms_h
 #define ServoInput_Platforms_h
 

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -40,6 +40,13 @@
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 #define SERVOINPUT_ISR_FLAG             ICACHE_RAM_ATTR
 
+#elif defined(__SAMD21G18A__)  // Arduino MKR boards, Arm Cortex-M0 SAMD21
+
+#define IO_REG_TYPE                     uint32_t
+#define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*((base)+8)) & (mask)) ? 1 : 0)
+
 #else
 #error "The ServoInput library does not support this board (platform). Please create a feature request here: https://github.com/dmadison/ServoInput/"
 #endif

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -47,9 +47,9 @@
 #elif defined(__SAMD21G18A__)  // Arduino MKR boards, Arm Cortex-M0 SAMD21
 
 #define IO_REG_TYPE                     uint32_t
-#define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
+#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
-#define DIRECT_PIN_READ(base, mask)     (((*((base)+8)) & (mask)) ? 1 : 0)
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
 #else
 #error "The ServoInput library does not support this board (platform). Please create a feature request here: https://github.com/dmadison/ServoInput/"


### PR DESCRIPTION
Adds support for the Arduino MKR boards which use the SAMD21 processor. Closes #12.