### PR TITLE
Create universal 'slow' read mode

### DIFF
--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -91,8 +91,8 @@ template<uint8_t Pin>
 class ServoInputPin : public ServoInputSignal {
 public:
 	ServoInputPin() {
-		ServoInputPin<Pin>::PinMask = PIN_TO_BITMASK(Pin);
-		ServoInputPin<Pin>::PortRegister = PIN_TO_BASEREG(Pin);
+		ServoInputPin<Pin>::PinMask = SERVOINPUT_PIN_TO_BITMASK(Pin);
+		ServoInputPin<Pin>::PortRegister = SERVOINPUT_PIN_TO_BASEREG(Pin);
 		pinMode(Pin, INPUT_PULLUP);
 
 		attachInterrupt();
@@ -168,7 +168,7 @@ public:
 	static void SERVOINPUT_ISR_FLAG isr() {
 		static unsigned long start = 0;
 
-		const boolean state = DIRECT_PIN_READ(PortRegister, PinMask);
+		const boolean state = SERVOINPUT_DIRECT_PIN_READ(PortRegister, PinMask);
 
 		if (state == HIGH) {  // rising edge
 			start = micros();
@@ -180,8 +180,8 @@ public:
 	}
 
 private:
-	static IO_REG_TYPE PinMask;  // bitmask to isolate the I/O pin
-	static volatile IO_REG_TYPE* PortRegister;  // pointer to the I/O register for the pin
+	static SERVOINPUT_IO_REG_TYPE PinMask;  // bitmask to isolate the I/O pin
+	static volatile SERVOINPUT_IO_REG_TYPE* PortRegister;  // pointer to the I/O register for the pin
 
 	static volatile boolean changed;
 	static volatile unsigned long pulseDuration;
@@ -196,8 +196,8 @@ private:
 	}
 };
 
-template<uint8_t Pin> IO_REG_TYPE ServoInputPin<Pin>::PinMask;
-template<uint8_t Pin> volatile IO_REG_TYPE* ServoInputPin<Pin>::PortRegister;
+template<uint8_t Pin> SERVOINPUT_IO_REG_TYPE ServoInputPin<Pin>::PinMask;
+template<uint8_t Pin> volatile SERVOINPUT_IO_REG_TYPE* ServoInputPin<Pin>::PortRegister;
 
 template<uint8_t Pin> volatile boolean ServoInputPin<Pin>::changed = false;
 template<uint8_t Pin> volatile unsigned long ServoInputPin<Pin>::pulseDuration = 0;
@@ -215,10 +215,10 @@ public:
 extern ServoInputManager ServoInput;
 
 // Clean up platform-specific register definitions
-#undef IO_REG_TYPE
-#undef PIN_TO_BASEREG
-#undef PIN_TO_BITMASK
-#undef DIRECT_PIN_READ
+#undef SERVOINPUT_IO_REG_TYPE
+#undef SERVOINPUT_PIN_TO_BASEREG
+#undef SERVOINPUT_PIN_TO_BITMASK
+#undef SERVOINPUT_DIRECT_PIN_READ
 #undef SERVOINPUT_ISR_FLAG
 
 #endif

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -184,12 +184,7 @@ public:
 		}
 	}
 
-private:
-#ifdef SERVOINPUT_PIN_SPECIALIZATION
-	static SERVOINPUT_IO_REG_TYPE PinMask;  // bitmask to isolate the I/O pin
-	static volatile SERVOINPUT_IO_REG_TYPE* PortRegister;  // pointer to the I/O register for the pin
-#endif
-
+protected:
 	static volatile boolean changed;
 	static volatile unsigned long pulseDuration;
 
@@ -201,6 +196,12 @@ private:
 		interrupts();
 		return pulse;
 	}
+
+#ifdef SERVOINPUT_PIN_SPECIALIZATION
+private:
+	static SERVOINPUT_IO_REG_TYPE PinMask;  // bitmask to isolate the I/O pin
+	static volatile SERVOINPUT_IO_REG_TYPE* PortRegister;  // pointer to the I/O register for the pin
+#endif
 };
 
 #ifdef SERVOINPUT_PIN_SPECIALIZATION

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -179,9 +179,9 @@ public:
 		}
 	}
 
-protected:
-	static IO_REG_TYPE PinMask;
-	static volatile IO_REG_TYPE* PortRegister;
+private:
+	static IO_REG_TYPE PinMask;  // bitmask to isolate the I/O pin
+	static volatile IO_REG_TYPE* PortRegister;  // pointer to the I/O register for the pin
 
 	static volatile boolean changed;
 	static volatile unsigned long pulseDuration;

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -31,32 +31,32 @@
 
 #if defined(__AVR__) || defined(TEENSYDUINO)
 
-#define IO_REG_TYPE                     uint8_t
-#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
-#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
-#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+#define SERVOINPUT_IO_REG_TYPE                     uint8_t
+#define SERVOINPUT_PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define SERVOINPUT_PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
 #elif defined(ESP8266) || defined(ESP32)
 
-#define IO_REG_TYPE                     uint32_t
-#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
-#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
-#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+#define SERVOINPUT_IO_REG_TYPE                     uint32_t
+#define SERVOINPUT_PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define SERVOINPUT_PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 #define SERVOINPUT_ISR_FLAG             ICACHE_RAM_ATTR
 
 #elif defined(__SAMD21G18A__)  // Arduino MKR boards, Arm Cortex-M0 SAMD21
 
-#define IO_REG_TYPE                     uint32_t
-#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
-#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
-#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+#define SERVOINPUT_IO_REG_TYPE                     uint32_t
+#define SERVOINPUT_PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define SERVOINPUT_PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
 #else  // Universal (slow) mode
 
-#define IO_REG_TYPE                     uint8_t
-#define PIN_TO_BASEREG(pin)             (nullptr)
-#define PIN_TO_BITMASK(pin)             (pin)
-#define DIRECT_PIN_READ(base, mask)     (digitalRead(mask) ? 1 : 0)
+#define SERVOINPUT_IO_REG_TYPE                     uint8_t
+#define SERVOINPUT_PIN_TO_BASEREG(pin)             (nullptr)
+#define SERVOINPUT_PIN_TO_BITMASK(pin)             (pin)
+#define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (digitalRead(mask) ? 1 : 0)
 
 #endif
 

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -51,8 +51,13 @@
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
-#else
-#error "The ServoInput library does not support this board (platform). Please create a feature request here: https://github.com/dmadison/ServoInput/"
+#else  // Universal (slow) mode
+
+#define IO_REG_TYPE                     uint8_t
+#define PIN_TO_BASEREG(pin)             (nullptr)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define DIRECT_PIN_READ(base, mask)     (digitalRead(mask) ? 1 : 0)
+
 #endif
 
 #ifndef SERVOINPUT_ISR_FLAG

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -29,6 +29,9 @@
 
 #include <Arduino.h>
 
+// Blanket define to cover all instances
+#define SERVOINPUT_PIN_SPECIALIZATION
+
 #if defined(__AVR__) || defined(TEENSYDUINO)
 
 #define SERVOINPUT_IO_REG_TYPE                     uint8_t
@@ -53,10 +56,7 @@
 
 #else  // Universal (slow) mode
 
-#define SERVOINPUT_IO_REG_TYPE                     uint8_t
-#define SERVOINPUT_PIN_TO_BASEREG(pin)             (nullptr)
-#define SERVOINPUT_PIN_TO_BITMASK(pin)             (pin)
-#define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (digitalRead(mask) ? 1 : 0)
+#undef SERVOINPUT_PIN_SPECIALIZATION
 
 #endif
 

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -45,7 +45,7 @@
 #define SERVOINPUT_PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define SERVOINPUT_PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define SERVOINPUT_DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
-#define SERVOINPUT_ISR_FLAG             ICACHE_RAM_ATTR
+#define SERVOINPUT_ISR_FLAG                        ICACHE_RAM_ATTR
 
 #elif defined(__SAMD21G18A__)  // Arduino MKR boards, Arm Cortex-M0 SAMD21
 


### PR DESCRIPTION
Using the built-in Arduino `digitalRead()` function instead of referencing the register. Significantly slower, but "should" work on just about every platform.

This also prefixes the preprocessor functions to avoid potential name collisions with headers included before ServoInput.