### PR TITLE
Disable pin checks if no platform support

### DIFF
--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -30,9 +30,9 @@
 #include <Arduino.h>
 
 
-// Define interrupt pin macro if it's not already defined by the platform
+// Disable interrupt checking if platform does not support pin checks
 #ifndef NOT_AN_INTERRUPT
-#define NOT_AN_INTERRUPT -1
+#define SERVOINPUT_DISABLE_PIN_CHECK
 #endif
 
 // Blanket define to cover all instances

--- a/src/ServoInput_Platforms.h
+++ b/src/ServoInput_Platforms.h
@@ -29,6 +29,12 @@
 
 #include <Arduino.h>
 
+
+// Define interrupt pin macro if it's not already defined by the platform
+#ifndef NOT_AN_INTERRUPT
+#define NOT_AN_INTERRUPT -1
+#endif
+
 // Blanket define to cover all instances
 #define SERVOINPUT_PIN_SPECIALIZATION
 


### PR DESCRIPTION
If a platform doesn't support checking if a given pin supports interrupts (using the `NOT_AN_INTERRUPT` define), disable the code snippets which check if a pin supports interrupts. Since we cannot tell which pins support interrupts, this also disables the pin-change interrupt feature on those platforms.

This should fix compilation issues on some platforms.

See issue #28 for reference.