### PR TITLE
Remove automatic interrupt attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ For more information, [see the article](https://www.partsnotincluded.com/servo-i
 
 ServoInputPin<2> servo;
 
-void setup() {}
+void setup() {
+	servo.attach();
+}
 
 void loop() {
 	float angle = servo.getAngle();  // get angle of servo (0 - 180)

--- a/examples/BasicAngle/BasicAngle.ino
+++ b/examples/BasicAngle/BasicAngle.ino
@@ -38,6 +38,7 @@ ServoInputPin<2> servo;
 
 void setup() {
 	Serial.begin(115200);
+	servo.attach();  // attaches the servo input interrupt
 
 	while (servo.available() == false) {
 		Serial.println("Waiting for servo signal...");

--- a/examples/BasicAngle/BasicAngle.ino
+++ b/examples/BasicAngle/BasicAngle.ino
@@ -38,6 +38,11 @@ ServoInputPin<2> servo;
 
 void setup() {
 	Serial.begin(115200);
+
+	while (servo.available() == false) {
+		Serial.println("Waiting for servo signal...");
+		delay(500);
+	}
 }
 
 void loop() {

--- a/examples/Calibration/Calibration.ino
+++ b/examples/Calibration/Calibration.ino
@@ -40,6 +40,7 @@ ServoInputPin<2> servo;
 
 void setup() {
 	Serial.begin(115200);
+	servo.attach();  // attaches the servo input interrupt
 
 	int center = servo.getRangeCenter();  // get center value of range
 	servo.setRange(center, center);  // set min/max values to center

--- a/examples/Loopback/Loopback.ino
+++ b/examples/Loopback/Loopback.ino
@@ -49,6 +49,7 @@ int waitTime = 10;  // milliseconds (ms)
 void setup() {
 	Serial.begin(115200);
 
+	inputServo.attach();  // attaches the servo input interrupt
 	outputServo.attach(OutputPin);  // attaches the servo on pin 9 to the servo object
 
 	while (inputServo.available() == false) {

--- a/examples/PinChangeInt/PinChange/PinChange.ino
+++ b/examples/PinChangeInt/PinChange/PinChange.ino
@@ -60,6 +60,8 @@ ISR(PCINT0_vect) {  // pin change ISR handler for Arduino Uno pins D8 - D13
 void setup() {
 	Serial.begin(115200);
 
+	// note that we do *not* need to call servo.attach(), because we are
+	// using our own custom interrupt service routine (ISR)
 	setInterrupt();  // set pin change interrupt (see above)
 
 	while (servo.available() == false) {

--- a/examples/PinChangeInt/PinChangeLib/PinChangeLib.ino
+++ b/examples/PinChangeInt/PinChangeLib/PinChangeLib.ino
@@ -53,6 +53,8 @@ ServoInputPin<pin2> servo2;
 
 void setup() {
 	Serial.begin(115200);
+	servo1.attach();  // attaches the first servo input interrupt
+	servo2.attach();  // attaches the second servo input interrupt
 
 	// wait for all servo signals to be read for the first time
 	while (!ServoInput.available()) {

--- a/examples/RC_Receiver/RC_Receiver.ino
+++ b/examples/RC_Receiver/RC_Receiver.ino
@@ -53,6 +53,8 @@ ServoInputPin<ThrottleSignalPin> throttle(ThrottlePulseMin, ThrottlePulseMax);
 
 void setup() {
 	Serial.begin(115200);
+	steering.attach();  // attaches the steering servo input interrupt
+	throttle.attach();  // attaches the throttle servo input interrupt
 
 	while (!ServoInput.available()) {  // wait for all signals to be ready
 		Serial.println("Waiting for servo signals...");

--- a/examples/Remapping/Remapping.ino
+++ b/examples/Remapping/Remapping.ino
@@ -38,6 +38,7 @@ ServoInputPin<2> servo;
 
 void setup() {
 	Serial.begin(115200);
+	servo.attach();  // attaches the servo input interrupt
 
 	while (servo.available() == false) {
 		Serial.println("Waiting for servo signal...");

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,8 +29,8 @@ getNumSignals	KEYWORD2
 # ISR
 isr	KEYWORD2
 
-attachInterrupt	KEYWORD2
-detachInterrupt	KEYWORD2
+attach	KEYWORD2
+detach	KEYWORD2
 
 getPin	KEYWORD2
 

--- a/src/ServoInput.cpp
+++ b/src/ServoInput.cpp
@@ -22,13 +22,13 @@
 
 #include "ServoInput.h"
 
-boolean ServoInputManager::available() {
+bool ServoInputManager::available() {
 	return allAvailable();
 }
 
-boolean ServoInputManager::allAvailable() {
+bool ServoInputManager::allAvailable() {
 	ServoInputSignal* ptr = ServoInputSignal::getHead();
-	boolean available = false;
+	bool available = false;
 
 	while (ptr != nullptr) {
 		available = ptr->available();
@@ -39,9 +39,9 @@ boolean ServoInputManager::allAvailable() {
 	return available;
 }
 
-boolean ServoInputManager::anyAvailable() {
+bool ServoInputManager::anyAvailable() {
 	ServoInputSignal* ptr = ServoInputSignal::getHead();
-	boolean available = false;
+	bool available = false;
 
 	while (ptr != nullptr) {
 		available = ptr->available();
@@ -132,7 +132,7 @@ float ServoInputSignal::getPercent() {
 	return (float) out / ScaleFactor;
 }
 
-boolean ServoInputSignal::getBoolean() {
+bool ServoInputSignal::getBoolean() {
 	const uint16_t pulse = getPulse();
 	return pulse > getRangeCenter();
 }
@@ -218,7 +218,7 @@ ServoInputSignal* ServoInputSignal::getNext() const {
 	return next;
 }
 
-boolean ServoInputSignal::pulseValidator(unsigned long pulse) {
+bool ServoInputSignal::pulseValidator(unsigned long pulse) {
 	return pulse >= PulseCenter - (PulseValidRange / 2)
 		&& pulse <= PulseCenter + (PulseValidRange / 2);
 }

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -96,14 +96,14 @@ public:
 			ServoInputPin<Pin>::PortRegister = SERVOINPUT_PIN_TO_BASEREG(Pin);
 		#endif
 		pinMode(Pin, INPUT_PULLUP);
-		attachInterrupt();
+		attach();
 	}
 
 	ServoInputPin(uint16_t pMin, uint16_t pMax) : ServoInputPin() {
 		ServoInputSignal::setRange(pMin, pMax);
 	}
 
-	void attachInterrupt() {
+	void attach() {
 		#if !defined(SERVOINPUT_NO_INTERRUPTS)
 
 			// Compile-time check that the selected pin supports interrupts
@@ -116,7 +116,7 @@ public:
 
 				// Interrupt attachment, platform support
 				if (digitalPinToInterrupt(Pin) != NOT_AN_INTERRUPT) {  // if pin supports external interrupts
-					::attachInterrupt(digitalPinToInterrupt(Pin), reinterpret_cast<void(*)()>(isr), CHANGE);
+					attachInterrupt(digitalPinToInterrupt(Pin), reinterpret_cast<void(*)()>(isr), CHANGE);
 				}
 
 				// Interrupt attachment, PinChangeInterrupt
@@ -131,13 +131,13 @@ public:
 			// because we have no way of checking whether the pin is supported
 			// in hardware vs in the library
 			#else
-				::attachInterrupt(digitalPinToInterrupt(Pin), reinterpret_cast<void(*)()>(isr), CHANGE);
+				attachInterrupt(digitalPinToInterrupt(Pin), reinterpret_cast<void(*)()>(isr), CHANGE);
 			#endif
 
 		#endif
 	}
 
-	void detachInterrupt() {
+	void detach() {
 		#if !defined(SERVOINPUT_NO_INTERRUPTS)
 
 			// Interrupt detachment, with pin checks
@@ -145,7 +145,7 @@ public:
 
 				// Interrupt detachment, platform support
 				if (digitalPinToInterrupt(Pin) != NOT_AN_INTERRUPT) {  // detach external interrupt
-					::detachInterrupt(digitalPinToInterrupt(Pin));
+					detachInterrupt(digitalPinToInterrupt(Pin));
 				}
 
 				// Interrupt detachment, PinChangeInterrupt
@@ -157,7 +157,7 @@ public:
 
 			// Interrupt detachment, no pin checks
 			#else
-				::detachInterrupt(digitalPinToInterrupt(Pin));
+				detachInterrupt(digitalPinToInterrupt(Pin));
 			#endif
 		#endif
 	}

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -96,7 +96,6 @@ public:
 			ServoInputPin<Pin>::PortRegister = SERVOINPUT_PIN_TO_BASEREG(Pin);
 		#endif
 		pinMode(Pin, INPUT_PULLUP);
-		attach();
 	}
 
 	ServoInputPin(uint16_t pMin, uint16_t pMax) : ServoInputPin() {

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -36,7 +36,7 @@ public:
 	ServoInputSignal();
 	~ServoInputSignal();
 
-	virtual boolean available() const = 0;
+	virtual bool available() const = 0;
 
 	uint16_t getPulse();
 	virtual unsigned long getPulseRaw() const = 0;
@@ -44,7 +44,7 @@ public:
 	float getAngle();
 	float getPercent();
 
-	boolean getBoolean();
+	bool getBoolean();
 
 	long map(long outMin, long outMax);
 
@@ -73,7 +73,7 @@ protected:
 	static const uint16_t PulseValidRange = 2000;   // us ( 500 - 2500)
 	static const uint16_t PulseDefaultRange = 1000;  // us (1000 - 2000)
 
-	static boolean pulseValidator(unsigned long pulse);
+	static bool pulseValidator(unsigned long pulse);
 
 	long remap(long pulse, long outMin, long outMax) const;
 
@@ -162,11 +162,11 @@ public:
 		#endif
 	}
 
-	boolean available() const {
-		boolean change = ServoInputPin<Pin>::changed;  // store temp version of volatile flag
+	bool available() const {
+		bool change = ServoInputPin<Pin>::changed;  // store temp version of volatile flag
 
 		if (change == true) {
-			boolean pulseValid = ServoInputSignal::pulseValidator(getPulseInternal());
+			bool pulseValid = ServoInputSignal::pulseValidator(getPulseInternal());
 
 			if (pulseValid == false) {
 				ServoInputPin<Pin>::changed = change = false;  // pulse is not valid, so we can reset (ignore) the 'changed' flag
@@ -175,10 +175,10 @@ public:
 		return change;
 	}
 
-	boolean read() {
+	bool read() {
 		unsigned long pulse = pulseIn(Pin, HIGH, 25000);  // 20 ms per + 5 ms of grace
 
-		boolean validPulse = pulseValidator(pulse);
+		bool validPulse = pulseValidator(pulse);
 		if (validPulse == true) {
 			pulseDuration = pulse;  // pulse is valid, store result
 		}
@@ -199,9 +199,9 @@ public:
 		static unsigned long start = 0;
 
 		#ifdef SERVOINPUT_PIN_SPECIALIZATION
-		const boolean state = SERVOINPUT_DIRECT_PIN_READ(PortRegister, PinMask);
+		const bool state = SERVOINPUT_DIRECT_PIN_READ(PortRegister, PinMask);
 		#else
-		const boolean state = digitalRead(Pin);
+		const bool state = digitalRead(Pin);
 		#endif
 
 		if (state == HIGH) {  // rising edge
@@ -214,7 +214,7 @@ public:
 	}
 
 protected:
-	static volatile boolean changed;
+	static volatile bool changed;
 	static volatile unsigned long pulseDuration;
 
 	static unsigned long getPulseInternal() {
@@ -238,15 +238,15 @@ template<uint8_t Pin> SERVOINPUT_IO_REG_TYPE ServoInputPin<Pin>::PinMask;
 template<uint8_t Pin> volatile SERVOINPUT_IO_REG_TYPE* ServoInputPin<Pin>::PortRegister;
 #endif
 
-template<uint8_t Pin> volatile boolean ServoInputPin<Pin>::changed = false;
+template<uint8_t Pin> volatile bool ServoInputPin<Pin>::changed = false;
 template<uint8_t Pin> volatile unsigned long ServoInputPin<Pin>::pulseDuration = 0;
 
 
 class ServoInputManager {
 public:
-	static boolean available();
-	static boolean allAvailable();
-	static boolean anyAvailable();
+	static bool available();
+	static bool allAvailable();
+	static bool anyAvailable();
 
 	static uint8_t getNumSignals();
 };


### PR DESCRIPTION
In order to read servo signals, the library attaches an interrupt handler to an interrupt-capable pin that fires whenever the pin changes state. The library reads the rising/falling edges and calculates the time elapsed between the two to find the length of the servo pulses.

On some platforms, notably the Uno R4 (#28) and ESP32 (#19) the interrupt request (IRQ) table is not set up until the `main()` function is entered. The version 1 library idiom, following Arduino-y convention, is to declare `ServoInputPin` objects as globals. These objects call the interrupt handler during the constructor to apply the function hook. Because the request table is not setup until `main()`, these calls fail and the library will not work until the user tries to attach the interrupt themselves.

This PR removes this call to attach the interrupt in the constructor, and instead requires the user do it themselves before the library can begin parsing signals. This is a breaking change to the API, and necessitates a new major library version.

Because of that, I've taken the opportunity to make a few other breaking changes:

* The library `attachInterrupt()` and `detachInterrupt()` functions have been refactored to simply `attach()` and `detach()`. This matches the syntax of the `Servo` library, and should fix issues with platforms that use macros instead of global functions for their interrupt handler (#27).
* All `boolean` types have been refactored to simply `bool`, which is the proper C type

Since the user is now responsible for interrupt attachment/detachment, I've also added reference counting that will automatically detach the interrupt whenever no more class instances for a given pin exist.