### PR TITLE
Virtual attach functions

### DIFF
--- a/examples/PinChangeInt/PinChangeLib/PinChangeLib.ino
+++ b/examples/PinChangeInt/PinChangeLib/PinChangeLib.ino
@@ -53,8 +53,7 @@ ServoInputPin<pin2> servo2;
 
 void setup() {
 	Serial.begin(115200);
-	servo1.attach();  // attaches the first servo input interrupt
-	servo2.attach();  // attaches the second servo input interrupt
+	ServoInput.attach();  // attach all inputs
 
 	// wait for all servo signals to be read for the first time
 	while (!ServoInput.available()) {

--- a/examples/RC_Receiver/RC_Receiver.ino
+++ b/examples/RC_Receiver/RC_Receiver.ino
@@ -53,8 +53,7 @@ ServoInputPin<ThrottleSignalPin> throttle(ThrottlePulseMin, ThrottlePulseMax);
 
 void setup() {
 	Serial.begin(115200);
-	steering.attach();  // attaches the steering servo input interrupt
-	throttle.attach();  // attaches the throttle servo input interrupt
+	ServoInput.attach();  // attach all inputs
 
 	while (!ServoInput.available()) {  // wait for all signals to be ready
 		Serial.println("Waiting for servo signals...");

--- a/src/ServoInput.cpp
+++ b/src/ServoInput.cpp
@@ -22,6 +22,24 @@
 
 #include "ServoInput.h"
 
+void ServoInputManager::attach() {
+	ServoInputSignal* ptr = ServoInputSignal::getHead();
+
+	while (ptr != nullptr) {
+		ptr->attach();
+		ptr = ptr->getNext();
+	}
+}
+
+void ServoInputManager::detach() {
+	ServoInputSignal* ptr = ServoInputSignal::getHead();
+
+	while (ptr != nullptr) {
+		ptr->detach();
+		ptr = ptr->getNext();
+	}
+}
+
 bool ServoInputManager::available() {
 	return allAvailable();
 }

--- a/src/ServoInput.h
+++ b/src/ServoInput.h
@@ -36,6 +36,9 @@ public:
 	ServoInputSignal();
 	virtual ~ServoInputSignal();
 
+	virtual void attach() = 0;
+	virtual void detach() = 0;
+
 	virtual bool available() const = 0;
 
 	uint16_t getPulse();
@@ -276,6 +279,9 @@ template<uint8_t Pin> volatile unsigned long ServoInputPin<Pin>::pulseDuration =
 
 class ServoInputManager {
 public:
+	static void attach();
+	static void detach();
+
 	static bool available();
 	static bool allAvailable();
 	static bool anyAvailable();


### PR DESCRIPTION
Now that attach() has to be done by the user (as of v2), it makes sense to add it to the management class so that all objects can be attached/detached at the same time.